### PR TITLE
Fix invisible text cursor in FindBar on dark background

### DIFF
--- a/compose-ui/src/main/java/com/bhuvaneshw/pdf/compose/ui/PdfToolBar.kt
+++ b/compose-ui/src/main/java/com/bhuvaneshw/pdf/compose/ui/PdfToolBar.kt
@@ -859,6 +859,7 @@ private fun PdfToolBarScope.FindBar(contentColor: Color, modifier: Modifier) {
             }),
             singleLine = true,
             textStyle = TextStyle(fontSize = 16.sp, color = contentColor),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.onBackground),
             modifier = Modifier
                 .fillMaxWidth()
                 .focusRequester(focusRequester)


### PR DESCRIPTION
### Summary
Fixed an issue in FindBar where the BasicTextField cursor was invisible on dark backgrounds.
Set the cursorBrush to use MaterialTheme.colorScheme.onBackground (just like fun GoToPageDialog -> BasicTextField in the same file) to ensure proper contrast
and visibility in both light and dark themes.

### Changes
- Updated cursorBrush in FindBar's BasicTextField to use Material color.
- Improved readability and consistency across themes.

### Testing
Verified on both light and dark modes to confirm cursor visibility and no regressions in FindBar behavior.